### PR TITLE
Tables loading indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
         "font-awesome": "^4.7.0",
         "vue-flatpickr-component": "^8.1.5",
         "vue-js-modal": "^1.3.33",
-        "vue-select": "^3.9.4",
         "vue-pagination-2": "^2.0.3",
         "vue-pagination-3": "^2.0.0-beta01",
+        "vue-select": "^3.9.4",
+        "vue-spinner": "^1.0.3",
         "vue-tables-2": "^2.0.20",
         "vue-toast-notification": "^0.2.0"
     }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,7 +1,7 @@
 require("./bootstrap");
 window.Vue = require("vue");
 
-import {ServerTable} from "vue-tables-2";
+import {ServerTable } from "vue-tables-2";
 import route from "ziggy";
 import {Ziggy} from "./routes"
 import components from "./components";

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -11,6 +11,7 @@ import ALVue from "@myshell/alvue";
 import VueToast from 'vue-toast-notification';
 import flatPickr from "vue-flatpickr-component";
 import vSelect from 'vue-select';
+import ClipLoader from "vue-spinner/src/ClipLoader.vue"
 
 import 'flatpickr/dist/flatpickr.css';
 import 'vue-select/dist/vue-select.css';
@@ -25,6 +26,7 @@ Vue.use(ServerTable, tablesConfig.options);
 Vue.mixin(tablesConfig.init);
 Vue.use(flatPickr);
 Vue.component('v-select', vSelect);
+Vue.component('clip-loader', ClipLoader);
 
 Vue.prototype.spanishFlatpickr = Spanish;
 

--- a/resources/js/components/countries/CountriesTable.vue
+++ b/resources/js/components/countries/CountriesTable.vue
@@ -4,10 +4,10 @@
                         :url="route('countries.index',{ filters: JSON.stringify(tableInterface.debouncedFilters),
                         columns:JSON.stringify(Object.keys(tableInterface.debouncedFilters))})" name="countries">
 
-            <template v-show="loading" slot="afterBody">
+            <div ref="loading" slot="afterBody">
                 <div class="overlay-loader"></div>
                 <clip-loader size="50px" class="clip-loader"></clip-loader>
-            </template>
+            </div>
 
             <div :slot="`filter__${column}`" v-for="column in filterable" v-if="headings.length">
                 <input type="text" class="form-control" v-model="tableInterface.filters[column]"
@@ -41,7 +41,8 @@
             <div slot="filter__formatted_created_at">
                 <fieldset>
                     <div class="input-group">
-                        <flat-pickr v-model="tableInterface.filters['formatted_created_at']" class="form-control search-input"
+                        <flat-pickr v-model="tableInterface.filters['formatted_created_at']"
+                                    class="form-control search-input"
                                     :config="dateConfig">
                         </flat-pickr>
                         <div class="input-group-append">
@@ -69,8 +70,8 @@
 <script>
     import CountriesTableColumns from "./CountriesTableColumns";
     import CountryModal from "./CountryModal";
-    import {Spanish} from 'flatpickr/dist/l10n/es.js';
-    import ClipLoader from 'vue-spinner/src/ClipLoader.vue'
+    import {Spanish} from "flatpickr/dist/l10n/es.js";
+    import ClipLoader from "vue-spinner/src/ClipLoader.vue"
     import {Event} from "vue-tables-2";
 
     export default {
@@ -89,8 +90,8 @@
                 },
                 dateConfig: {
                     mode: "range",
-                    dateFormat: 'Y-m-d',
-                    altFormat: 'M j, Y',
+                    dateFormat: "Y-m-d",
+                    altFormat: "M j, Y",
                     locale: Spanish,
                     wrap: true,
                     altInput: true,
@@ -99,14 +100,14 @@
             }
         },
         mounted() {
-            Event.$on('vue-tables.countries.loading', () => {
-                this.loading = true;
-                //console.log("LOADING... " + this.loading);
+            Event.$on("vue-tables.countries.loading", () => {
+                this.$refs.loading.style.display = "block"
+
             });
 
-            Event.$on('vue-tables.countries.loaded',() => {
-                this.loading = false;
-                //console.log("LODADED... " + this.loading);
+            Event.$on("vue-tables.countries.loaded", () => {
+                this.$refs.loading.style.display = "none"
+
             });
         },
         methods: {

--- a/resources/js/components/countries/CountriesTable.vue
+++ b/resources/js/components/countries/CountriesTable.vue
@@ -72,7 +72,6 @@
     import CountryModal from "./CountryModal";
     import {Spanish} from "flatpickr/dist/l10n/es.js";
     import ClipLoader from "vue-spinner/src/ClipLoader.vue"
-    import {Event} from "vue-tables-2";
 
     export default {
         name: "countriesTable",
@@ -98,17 +97,6 @@
                 },
                 loading: false,
             }
-        },
-        mounted() {
-            Event.$on("vue-tables.countries.loading", () => {
-                this.$refs.loading.style.display = "block"
-
-            });
-
-            Event.$on("vue-tables.countries.loaded", () => {
-                this.$refs.loading.style.display = "none"
-
-            });
         },
         methods: {
             reloadTable() {

--- a/resources/js/components/countries/CountriesTable.vue
+++ b/resources/js/components/countries/CountriesTable.vue
@@ -2,7 +2,13 @@
     <div class="table">
         <v-server-table :options="options" ref="table" :columns="columns" class=" table-borderless"
                         :url="route('countries.index',{ filters: JSON.stringify(tableInterface.debouncedFilters),
-                        columns:JSON.stringify(Object.keys(tableInterface.debouncedFilters))})">
+                        columns:JSON.stringify(Object.keys(tableInterface.debouncedFilters))})" name="countries">
+
+            <template v-show="loading" slot="afterBody">
+                <div class="overlay-loader"></div>
+                <clip-loader size="50px" class="clip-loader"></clip-loader>
+            </template>
+
             <div :slot="`filter__${column}`" v-for="column in filterable" v-if="headings.length">
                 <input type="text" class="form-control" v-model="tableInterface.filters[column]"
                        :style="'max-width:'+(column=='id'?'50px':'auto')">
@@ -64,11 +70,14 @@
     import CountriesTableColumns from "./CountriesTableColumns";
     import CountryModal from "./CountryModal";
     import {Spanish} from 'flatpickr/dist/l10n/es.js';
+    import ClipLoader from 'vue-spinner/src/ClipLoader.vue'
+    import {Event} from "vue-tables-2";
 
     export default {
         name: "countriesTable",
         components: {
-            CountryModal
+            CountryModal,
+            "clip-loader": ClipLoader
         },
         data() {
             return {
@@ -86,7 +95,19 @@
                     wrap: true,
                     altInput: true,
                 },
+                loading: false,
             }
+        },
+        mounted() {
+            Event.$on('vue-tables.countries.loading', () => {
+                this.loading = true;
+                //console.log("LOADING... " + this.loading);
+            });
+
+            Event.$on('vue-tables.countries.loaded',() => {
+                this.loading = false;
+                //console.log("LODADED... " + this.loading);
+            });
         },
         methods: {
             reloadTable() {
@@ -122,3 +143,27 @@
     }
 </script>
 
+<style>
+    table {
+        width: 100%;
+        position: relative;
+    }
+
+    .overlay-loader {
+        position: absolute;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        background-color: white;
+        opacity: 0.8;
+        filter: blur(5px);
+    }
+
+    .clip-loader {
+        position: absolute;
+        left: 50%;
+        right: 50%;
+        bottom: 60%;
+        top: 40%;
+    }
+</style>

--- a/resources/js/components/countries/CountriesTable.vue
+++ b/resources/js/components/countries/CountriesTable.vue
@@ -71,13 +71,11 @@
     import CountriesTableColumns from "./CountriesTableColumns";
     import CountryModal from "./CountryModal";
     import {Spanish} from "flatpickr/dist/l10n/es.js";
-    import ClipLoader from "vue-spinner/src/ClipLoader.vue"
 
     export default {
         name: "countriesTable",
         components: {
             CountryModal,
-            "clip-loader": ClipLoader
         },
         data() {
             return {
@@ -95,7 +93,6 @@
                     wrap: true,
                     altInput: true,
                 },
-                loading: false,
             }
         },
         methods: {
@@ -131,28 +128,3 @@
         }
     }
 </script>
-
-<style>
-    table {
-        width: 100%;
-        position: relative;
-    }
-
-    .overlay-loader {
-        position: absolute;
-        top: 0;
-        width: 100%;
-        height: 100%;
-        background-color: white;
-        opacity: 0.8;
-        filter: blur(5px);
-    }
-
-    .clip-loader {
-        position: absolute;
-        left: 50%;
-        right: 50%;
-        bottom: 60%;
-        top: 40%;
-    }
-</style>

--- a/resources/js/components/marital-states/MaritalStatesTable.vue
+++ b/resources/js/components/marital-states/MaritalStatesTable.vue
@@ -2,7 +2,13 @@
     <div class="table">
         <v-server-table :options="options" ref="table" :columns="columns" class=" table-borderless"
                         :url="route('marital.states.index',{ filters: JSON.stringify(tableInterface.debouncedFilters),
-                        columns:JSON.stringify(Object.keys(tableInterface.debouncedFilters))})">
+                        columns:JSON.stringify(Object.keys(tableInterface.debouncedFilters))})" name="marital-states">
+
+            <div ref="loading" slot="afterBody">
+                <div class="overlay-loader"></div>
+                <clip-loader size="50px" class="clip-loader"></clip-loader>
+            </div>
+
             <div :slot="`filter__${column}`" v-for="column in filterable" v-if="headings.length">
                 <input type="text" class="form-control" v-model="tableInterface.filters[column]"
                        :style="'max-width:'+(column=='id'?'50px':'auto')">

--- a/resources/js/components/states/StatesTable.vue
+++ b/resources/js/components/states/StatesTable.vue
@@ -2,7 +2,13 @@
     <div class="table">
         <v-server-table :options="options" ref="table" :columns="columns" class=" table-borderless"
                         :url="route('states.index',{ filters: JSON.stringify(tableInterface.debouncedFilters),
-                        columns:JSON.stringify(Object.keys(tableInterface.debouncedFilters))})">
+                        columns:JSON.stringify(Object.keys(tableInterface.debouncedFilters))})" name="states">
+
+            <div ref="loading" slot="afterBody">
+                <div class="overlay-loader"></div>
+                <clip-loader size="50px" class="clip-loader"></clip-loader>
+            </div>
+
             <div :slot="`filter__${column}`" v-for="column in filterable" v-if="headings.length">
                 <input type="text" class="form-control" v-model="tableInterface.filters[column]"
                        :style="'max-width:'+(column=='id'?'50px':'auto')">

--- a/resources/js/components/users/UsersTable.vue
+++ b/resources/js/components/users/UsersTable.vue
@@ -1,7 +1,14 @@
 <template>
     <div class="table">
         <v-server-table :options="options" ref="table" :columns="columns" class=" table-borderless"
-                        :url="route('users.index',{ filters: JSON.stringify(tableInterface.debouncedFilters), columns:JSON.stringify([])})">
+                        :url="route('users.index',{ filters: JSON.stringify(tableInterface.debouncedFilters), columns:JSON.stringify([])})"
+                        name="users">
+
+            <div ref="loading" slot="afterBody">
+                <div class="overlay-loader"></div>
+                <clip-loader size="50px" class="clip-loader"></clip-loader>
+            </div>
+
             <div :slot="`filter__${column}`" v-for="column in filterable" v-if="headings.length">
                 <input type="text" class="form-control" v-model="tableInterface.filters[column]"
                        :style="'max-width:'+(column=='id'?'50px':'auto')">

--- a/resources/js/tables_config.js
+++ b/resources/js/tables_config.js
@@ -50,7 +50,7 @@ export default {
             const vm = this;
             if (vm.$parent && vm.$parent.$options.name === 'VtServerTable') {
 
-                Event.$on("vue-tables.countries.loaded", () => {
+                Event.$on(`vue-tables.${vm.$parent.name}.loaded`, () => {
                     vm.$parent.$parent.$refs.loading.style.display = "none"
                 });
                 const columns = vm.options.columns;

--- a/resources/js/tables_config.js
+++ b/resources/js/tables_config.js
@@ -1,3 +1,5 @@
+import {Event} from "vue-tables-2";
+
 export default {
     options: {
         requestFunction(data) {
@@ -5,6 +7,7 @@ export default {
             const equalsRoute = JSON.stringify(this.url) != JSON.stringify(this.currentURL);
             if (this.options.loaded && (typeof this.currentURL == 'undefined' || equalsRoute)) {
                 this.currentURL = this.url.url();
+                this.$parent.$parent.$refs.loading.style.display = "block";
                 return axios.get(this.url).catch(function (e) {
                     this.dispatch('error', e);
                 }.bind(this));
@@ -47,6 +50,9 @@ export default {
             const vm = this;
             if (vm.$parent && vm.$parent.$options.name === 'VtServerTable') {
 
+                Event.$on("vue-tables.countries.loaded", () => {
+                    vm.$parent.$parent.$refs.loading.style.display = "none"
+                });
                 const columns = vm.options.columns;
                 const parentName = vm.$parent.$parent.$options.name;
                 const default_headings = Object.keys(columns).map(column => ({

--- a/resources/sass/_tables.scss
+++ b/resources/sass/_tables.scss
@@ -46,3 +46,27 @@
 .VuePagination .VuePagination__count {
     padding: 0;
 }
+
+//Loading indicator CSS
+table {
+    width: 100%;
+    position: relative;
+}
+
+.overlay-loader {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: white;
+    opacity: 0.8;
+    filter: blur(5px);
+}
+
+.clip-loader {
+    position: absolute;
+    left: 50%;
+    right: 50%;
+    bottom: 60%;
+    top: 40%;
+}


### PR DESCRIPTION
Was added tables loading indicator, that is configured into table.js file.

You only need add a `name` attribute to `<v-server-table>`tag

And add slot like this 

```javascript
<div ref="loading" slot="afterBody">
    <div class="overlay-loader"></div>
    <clip-loader size="50px" class="clip-loader"></clip-loader>
</div>
```